### PR TITLE
fix: Resolve Next.js production caching issue

### DIFF
--- a/app/admin/blog/edit/[id]/page.tsx
+++ b/app/admin/blog/edit/[id]/page.tsx
@@ -99,7 +99,7 @@ export default function BlogEditorPage() {
   const fetchPost = async (id: string) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/admin/blog`);
+      const response = await fetch(`/api/admin/blog`, { cache: 'no-store' });
       if (response.ok) {
         const posts = await response.json();
         const post = posts.find((p: any) => p.id === id);

--- a/app/admin/blog/new/page.tsx
+++ b/app/admin/blog/new/page.tsx
@@ -92,7 +92,7 @@ export default function BlogEditorPage() {
   const fetchPost = async (id: string) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/admin/blog`);
+      const response = await fetch(`/api/admin/blog`, { cache: 'no-store' });
       if (response.ok) {
         const posts = await response.json();
         const post = posts.find((p: any) => p.id === id);

--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -39,7 +39,7 @@ export default function BlogAdminPage() {
 
   const fetchPosts = async () => {
     try {
-      const response = await fetch("/api/admin/blog")
+      const response = await fetch("/api/admin/blog", { cache: 'no-store' })
       
       if (!response.ok) {
         throw new Error("Failed to fetch blog posts")

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -27,10 +27,10 @@ export default function AdminDashboard() {
       setLoading(true)
       try {
         const [servicesRes, teamRes, locationsRes, blogRes] = await Promise.all([
-          fetch("/api/admin/services"),
-          fetch("/api/admin/team"),
-          fetch("/api/admin/locations"),
-          fetch("/api/admin/blog"),
+          fetch("/api/admin/services", { cache: 'no-store' }),
+          fetch("/api/admin/team", { cache: 'no-store' }),
+          fetch("/api/admin/locations", { cache: 'no-store' }),
+          fetch("/api/admin/blog", { cache: 'no-store' }),
         ])
 
         const services = await servicesRes.json()

--- a/app/admin/locations/edit/[id]/page.tsx
+++ b/app/admin/locations/edit/[id]/page.tsx
@@ -42,7 +42,7 @@ export default function EditLocationPage() {
       async function fetchLocation() {
         setLoading(true)
         try {
-          const response = await fetch(`/api/admin/locations/${id}`)
+          const response = await fetch(`/api/admin/locations/${id}`, { cache: 'no-store' })
           if (!response.ok) {
             throw new Error("Failed to fetch location")
           }

--- a/app/admin/locations/page.tsx
+++ b/app/admin/locations/page.tsx
@@ -29,7 +29,7 @@ export default function LocationsPage() {
   useEffect(() => {
     async function fetchLocations() {
       try {
-        const response = await fetch("/api/admin/locations")
+        const response = await fetch("/api/admin/locations", { cache: 'no-store' })
         if (!response.ok) {
           throw new Error("Failed to fetch locations")
         }

--- a/app/admin/services/edit/[id]/page.tsx
+++ b/app/admin/services/edit/[id]/page.tsx
@@ -40,6 +40,7 @@ export default function EditServicePage({ params }: { params: { id: string } }) 
         setFetchLoading(true);
         const token = localStorage.getItem("admin_token");
         const response = await fetch(`/api/admin/services/${params.id}`, {
+          cache: 'no-store',
           headers: {
             Authorization: `Bearer ${token}`,
           },

--- a/app/admin/services/edit/page.tsx
+++ b/app/admin/services/edit/page.tsx
@@ -12,7 +12,7 @@ export default function EditServicePage({ params }: { params: { id: string } }) 
 
   useEffect(() => {
     const fetchService = async () => {
-      const response = await fetch(`/api/admin/services/${params.id}`);
+      const response = await fetch(`/api/admin/services/${params.id}`, { cache: 'no-store' });
       if (response.ok) {
         const data = await response.json();
         setTitle(data.title);

--- a/app/admin/services/page.tsx
+++ b/app/admin/services/page.tsx
@@ -21,6 +21,7 @@ export default function AdminServicesPage() {
     try {
       const token = localStorage.getItem("admin_token")
       const response = await fetch("/api/admin/services", {
+        cache: 'no-store',
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/app/admin/team/edit/[id]/page.tsx
+++ b/app/admin/team/edit/[id]/page.tsx
@@ -35,7 +35,7 @@ export default function EditTeamMemberPage({ params }: { params: Promise<{ id: s
     const fetchTeamMember = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/api/admin/team/${id}`);
+        const res = await fetch(`/api/admin/team/${id}`, { cache: 'no-store' });
         const data: TeamMember = await res.json();
         if (res.ok) {
           setName(data.name);

--- a/app/admin/team/page.tsx
+++ b/app/admin/team/page.tsx
@@ -21,7 +21,7 @@ export default function TeamListPage() {
   useEffect(() => {
     const fetchTeamMembers = async () => {
       try {
-        const res = await fetch("/api/admin/team")
+        const res = await fetch("/api/admin/team", { cache: 'no-store' })
         if (!res.ok) {
           throw new Error("Failed to fetch team members")
         }

--- a/app/api/admin/blog/[id]/route.ts
+++ b/app/api/admin/blog/[id]/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getBlogPostById, updateBlogPost, deleteBlogPost } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/blog/route.ts
+++ b/app/api/admin/blog/route.ts
@@ -1,4 +1,7 @@
 
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getBlogPosts, createBlogPost } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/locations/[id]/route.ts
+++ b/app/api/admin/locations/[id]/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getLocationById, updateLocation, deleteLocation } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/locations/route.ts
+++ b/app/api/admin/locations/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getLocations, createLocation } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/services/[id]/route.ts
+++ b/app/api/admin/services/[id]/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextRequest, NextResponse } from "next/server"
 import { getServiceById, updateService, deleteService } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/services/route.ts
+++ b/app/api/admin/services/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getServices, createService } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/team/[id]/route.ts
+++ b/app/api/admin/team/[id]/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { getTeamMemberById, updateTeamMember, deleteTeamMember, TeamMember } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/admin/team/route.ts
+++ b/app/api/admin/team/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from "next/server"
 import { createTeamMember, getTeamMembers, TeamMember } from "@/lib/db"
 import { revalidate } from "@/lib/revalidate"

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import { NextResponse } from 'next/server';
 import { searchBlogPosts } from '@/lib/db';
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import Link from "next/link"
 import Image from "next/image"
 import { notFound } from "next/navigation"

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import Link from "next/link"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"

--- a/app/firm-profile/team/[slug]/page.tsx
+++ b/app/firm-profile/team/[slug]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { getTeamMember } from "../../../../lib/db"
 import { notFound } from "next/navigation"
 import Image from "next/image"

--- a/app/locations/[location]/page.tsx
+++ b/app/locations/[location]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import React from "react"
 import Image from "next/image"
 import { Button } from "@/components/ui/button"

--- a/app/locations/page.tsx
+++ b/app/locations/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import Image from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import type { Metadata } from "next"
 import Link from "next/link"
 import Image from "next/image"

--- a/app/services/[service]/page.tsx
+++ b/app/services/[service]/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { notFound } from "next/navigation"
 import Image from "next/image"
 import Link from "next/link"

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import ServiceCard from "@/components/service-card"


### PR DESCRIPTION
This commit addresses a critical issue where content updated in Firebase was not appearing on the live Vercel deployment due to Next.js's default static rendering and caching behavior.

The following changes were implemented:

1.  **Forced Dynamic Rendering on Pages:** Added `export const dynamic = 'force-dynamic';` to all public-facing pages that fetch data directly from Firestore (`app/services`, `app/blog`, `app/team`, `app/locations`, and their respective slug pages). This ensures these pages are always server-rendered at request time with the latest data, preventing stale content from being served.

2.  **Disabled Caching on API Routes:** Added `export const dynamic = 'force-dynamic';` and `export const revalidate = 0;` to all data-fetching API routes, primarily within the `/app/api/admin/` directory. This prevents Vercel from caching the API responses, ensuring the admin dashboard always interacts with live data.

3.  **Prevented Client-Side Fetch Caching:** Added the `{ cache: 'no-store' }` option to all relevant client-side `fetch` calls within the admin dashboard components. This prevents the Next.js Data Cache from caching responses on the client side, ensuring that UI components always reflect the latest database state.

These changes work together to disable Next.js's static caching behavior for dynamic content, ensuring that new data from Firebase is reflected on the live site immediately upon upload.